### PR TITLE
upgrade to storyteller 8.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     
-    def storyteller_version = "8.0.1"
+    def storyteller_version = "8.0.2"
     implementation(group: "Storyteller", name: "sdk", version: "$storyteller_version")
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
### 🛠 Changelog

#### 8.0.2

- fixing an issue where it was possible for a progress indicator to stay on a Poll page
- fixing an issue where the live chip was not aligned correctly on a tile
- fixing an issue with `lists.grid.colums` in theme